### PR TITLE
Fix Safari rendering glitch

### DIFF
--- a/part1.html
+++ b/part1.html
@@ -16,7 +16,7 @@ a.sourceLine { display: inline-block; line-height: 1.25; }
 a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
 a.sourceLine:empty { height: 1.2em; position: absolute; }
 .sourceCode { overflow: visible; }
-code.sourceCode { white-space: pre; position: relative; }
+code.sourceCode { white-space: pre; }
 div.sourceCode { margin: 1em 0; }
 pre.sourceCode { margin: 0; }
 @media screen {


### PR DESCRIPTION
Fixes https://github.com/moocfi/haskell-mooc/issues/8

Code examples were not rendered properly in Safari (macOS, iOS) when `code.sourceCode` was set to `position: relative`. Should not cause any regressions. Demo: https://haskell-mooc.netlify.app