### PR TITLE
build(extra-deps): adds control.monad.state as extra dependencies for…

### DIFF
--- a/exercises/stack.yaml
+++ b/exercises/stack.yaml
@@ -1,2 +1,5 @@
 resolver: lts-16.31
 install-ghc: true
+
+extra-deps:
+- mtl-2.2.2

--- a/exercises/tests.cabal
+++ b/exercises/tests.cabal
@@ -4,5 +4,5 @@ build-type: Simple
 cabal-version: >= 1.10
 
 library
-  build-depends: QuickCheck, hspec, base, containers, array, transformers, template-haskell, generic-random, JuicyPixels, HTTP
+  build-depends: QuickCheck, hspec, base, containers, array, transformers, template-haskell, generic-random, JuicyPixels, HTTP, mtl
   default-language: Haskell2010


### PR DESCRIPTION
… stack

### what's changed

1. added `mtl` with version set to `2.2.2` for `stack.yaml` 
2. added `mtl` to `tests.cabal`

### Reason for change
Not including the required packages causes an error when opening `Set13a.hs` in vscode with the Haskell Language Server. Specifically, the error messages says that `Control.Monad.State` is a hidden package and could not be loaded because of that. This leads to the extension being unable to lint the source files due to this error. The solution was to make the package visible to stack and run the `stack build` command 

**note** 
i'm not actually sure whether the `stack.yaml` change is needed (would appreciate an explanation on this!)