### PR TITLE
Fix inconsistency in example within section 12.5.

### DIFF
--- a/part2.html
+++ b/part2.html
@@ -2316,7 +2316,7 @@ Query the user for a number and return it.
 <a class="sourceLine" id="cb200-2" data-line-number="2">fmap (<span class="fu">+</span><span class="dv">1</span>) [<span class="dv">3</span>,<span class="dv">6</span>]        <span class="fu">==&gt;</span> [<span class="dv">4</span>,<span class="dv">7</span>]</a>
 <a class="sourceLine" id="cb200-3" data-line-number="3"></a>
 <a class="sourceLine" id="cb200-4" data-line-number="4">foldr (<span class="fu">*</span>) <span class="dv">1</span> (<span class="dt">Pair</span> <span class="dv">3</span> <span class="dv">6</span>) <span class="fu">==&gt;</span> <span class="dv">18</span></a>
-<a class="sourceLine" id="cb200-5" data-line-number="5">foldr (<span class="fu">*</span>) <span class="dv">1</span> [<span class="dv">3</span>,<span class="dv">6</span>] <span class="fu">==&gt;</span> <span class="dv">18</span></a>
+<a class="sourceLine" id="cb200-5" data-line-number="5">foldr (<span class="fu">*</span>) <span class="dv">1</span> [<span class="dv">3</span>,<span class="dv">6</span>]      <span class="fu">==&gt;</span> <span class="dv">18</span></a>
 <a class="sourceLine" id="cb200-6" data-line-number="6"></a>
 <a class="sourceLine" id="cb200-7" data-line-number="7">length (<span class="dt">Pair</span> <span class="dv">3</span> <span class="dv">6</span>)      <span class="fu">==&gt;</span> <span class="dv">2</span></a>
 <a class="sourceLine" id="cb200-8" data-line-number="8">length [<span class="dv">3</span>,<span class="dv">6</span>]           <span class="fu">==&gt;</span> <span class="dv">2</span></a>


### PR DESCRIPTION
The line `foldr (*) 1 (Pair 3 6) ==> 18` occurs twice in the example. Replace the second occurrence with `foldr (*) 1 [3,6]`, as the example is all about illustrating how `Pair` as implemented can be used almost everywhere a list can be used.