### PR TITLE
add workaround for line edit bug on arm systems

### DIFF
--- a/part1.html
+++ b/part1.html
@@ -286,6 +286,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>The easiest way to get Haskell is to install the <code>stack</code> tool, see <a href="https://haskellstack.org" class="uri">https://haskellstack.org</a>. The exercises on this course are intended to work with Stack, so you should use it for now.</p>
 <p>By the way, if you’re interested in what Stack is, and how it relates to other Haskell tools like Cabal and GHC, <a href="https://www.quora.com/What-is-the-difference-between-Cabal-and-Stack-in-Haskell-projects-Which-one-do-you-recommend-and-why">read more here</a> or <a href="https://docs.haskellstack.org/en/stable/faq/">here</a>. We’ll get back to Haskell packages and using them in detail in part 2 of the course.</p>
 <p>For now, after installing Stack, just run <code>stack ghci</code> to get an interactive Haskell environment.</p>
+<p><strong>NB!</strong> If you are using an ARM-based system, line edit behaves weirdly as of GHCi 8.10.7. As a workaround, use <code>TERM=dumb stack ghci</code>. For more info, you can read <span><a href="https://gitlab.haskell.org/ghc/ghc/-/issues/20022">this GitLab issue.</a></span></p>
 <h2 data-number="1.5" id="lets-start"><span class="header-section-number">1.5</span> Let’s Start!</h2>
 <p>GHCi is the interactive Haskell interpreter. Here’s an example session:</p>
 <pre><code>$ stack ghci


### PR DESCRIPTION
Currently line edit in GHCi does not work correctly on arm64 systems. 

This commit adds a simple workaround to the material. 