### PR TITLE
Minor typo in Set16b.hs

### DIFF
--- a/exercises/Set16b.hs
+++ b/exercises/Set16b.hs
@@ -66,7 +66,7 @@ toLast = todo
 -- toFull should combine a first and a last name into a full name. Give
 -- toFull the correct type (see examples below).
 --
--- capitalize shouldCapitalize the first letter of a name. Give
+-- capitalize should capitalize the first letter of a name. Give
 -- capitalize the correct type (see examples below).
 --
 -- Examples:


### PR DESCRIPTION
shouldCapitalize -> should capitalize

Not sure if it's an actual typo or it's intended to avoid the clash with the actual function name `capitalize`.

P.S. Thank you for such a lovely course!