### PR TITLE
Set13b: foldM behaves like foldl (not foldr)

### DIFF
--- a/exercises/Set13b.hs
+++ b/exercises/Set13b.hs
@@ -191,7 +191,7 @@ allSums xs = todo
 --
 --   foldM :: (Monad m) => (a -> b -> m a) -> a -> [b] -> m a
 --
--- This function behaves like foldr, but the operation used is
+-- This function behaves like foldl, but the operation used is
 -- monadic. foldM f acc xs works by running f for each element in xs,
 -- giving it also the result of the previous invocation of f.
 --


### PR DESCRIPTION
From the [documentation for foldM](https://hackage.haskell.org/package/base-4.17.0.0/docs/Control-Monad.html#v:foldM):
> The foldM function is analogous to foldl, except that its result is encapsulated in a monad. Note that foldM works from left-to-right over the list arguments.