### PR TITLE
Make test for Set13a ex4 more thorough

### DIFF
--- a/exercises/Set11bTest.hs
+++ b/exercises/Set11bTest.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell, ScopedTypeVariables #-}
 
-module Set11aTest where
+module Set11bTest where
 
 import Mooc.Test
 import Mooc.Th

--- a/exercises/Set13aTest.hs
+++ b/exercises/Set13aTest.hs
@@ -106,9 +106,10 @@ ex4 = property $ do
   i <- choose (0::Int,10)
   is <- listOf (choose (0,10) `suchThat` (/=i))
   n <- choose (0,5)
-  input <- shuffle (replicate n i ++ is)
-  return $ counterexample ("countAndLog (=="++show i++") "++show input) $
-    countAndLog (==i) input ?== Logger (replicate n (show i)) n
+  input <- shuffle $ zip (replicate n i ++ is) [0..]
+  let goods = filter ((< n) . snd) input
+  return $ counterexample ("countAndLog ((=="++show i++") . fst) "++show input) $
+    countAndLog ((==i) . fst) input ?== Logger (map show $ goods) n
 
 ex5_balance_examples =
   conjoin [$(testing' [|runBankOp (balance "harry") exampleBank|]) (?==(10,exampleBank))


### PR DESCRIPTION
Long story short, the test for ex4 would pass even if the solution appends the logs in reverse order.

Here I'm `zip`ping the randomly generated numbers with `[0..]`, in order to keep track of them despite the `shuffle`.