### PR TITLE
Fix typos part1.html & part2.html

### DIFF
--- a/part1.html
+++ b/part1.html
@@ -1398,7 +1398,7 @@ fib 5        ==>          |           |
                                                   1       1
 ```
 -->
-<p>This tree then exaclty corresponds with the expression
+<p>This tree then exactly corresponds with the expression
 <code>(1 + 1) + (1 + (1 + 1))</code>. Recursion can often produce
 chain-like, tree-like, nested, or loopy structures and computations.
 Recursion is one of the main techniques in functional programming, so
@@ -1407,7 +1407,7 @@ it’s worth spending some effort in learning it.</p>
 <h2 data-number="1.10" id="all-together-now"><span
 class="header-section-number">1.10</span> All Together Now!</h2>
 <p>Finally, here’s a complete Haskell module that uses ifs, pattern
-matching, local defintions and recursion. The module is interested in
+matching, local definitions and recursion. The module is interested in
 the <a
 href="https://en.wikipedia.org/wiki/Collatz_conjecture"><em>Collatz
 conjecture</em></a>, a famous open problem in mathematics. It asks:</p>
@@ -1550,7 +1550,7 @@ If you can’t seem to get indentation to work, try putting everything on
 just one long line at first.</p>
 <h2 data-number="1.12" id="quiz"><span
 class="header-section-number">1.12</span> Quiz</h2>
-<p>At the end of each lecture you’ll find a quiz like this. The quizes
+<p>At the end of each lecture you’ll find a quiz like this. The quizzes
 aren’t graded, they’re just here to help you check you’ve understood the
 chapter. You can check your answer by clicking on an option. You’ll see
 a green background if you were right, a red one if you were wrong. Feel
@@ -4250,7 +4250,7 @@ course.</p>
 over. The true type of <code>foldr</code> is:</p>
 <div class="sourceCode" id="cb308"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb308-1"><a href="#cb308-1" aria-hidden="true" tabindex="-1"></a><span class="fu">foldr</span><span class="ot"> ::</span> <span class="dt">Foldable</span> t <span class="ot">=&gt;</span> (a <span class="ot">-&gt;</span> b <span class="ot">-&gt;</span> b) <span class="ot">-&gt;</span> b <span class="ot">-&gt;</span> t a <span class="ot">-&gt;</span> b</span></code></pre></div>
-<p>We’ve succesfully used the fact that lists are <code>Foldable</code>
+<p>We’ve successfully used the fact that lists are <code>Foldable</code>
 since we’ve managed to use <code>length</code> and <code>foldr</code> on
 lists. However, <code>Maybe</code> is also <code>Foldable</code>! The
 <code>Foldable</code> instance for <code>Maybe</code> just pretends that
@@ -4844,7 +4844,7 @@ thing with a type parameter. This is the same as the built in type
 <div class="sourceCode" id="cb350"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb350-1"><a href="#cb350-1" aria-hidden="true" tabindex="-1"></a><span class="kw">data</span> <span class="dt">List</span> a <span class="ot">=</span> <span class="dt">Empty</span> <span class="op">|</span> <span class="dt">Node</span> a (<span class="dt">List</span> a)</span>
 <span id="cb350-2"><a href="#cb350-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">deriving</span> <span class="dt">Show</span></span></code></pre></div>
-<p>Note how we need to pass the the type parameter <code>a</code>
+<p>Note how we need to pass the type parameter <code>a</code>
 onwards in the recursion. We need to write <code>Node a (List a)</code>
 instead of <code>Node a List</code>. The <code>Node</code> constructor
 has two arguments. The first has type <code>a</code>, and the second has
@@ -4938,7 +4938,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb357-1"><
 <span id="cb357-12"><a href="#cb357-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">==&gt;</span> <span class="dv">1</span> <span class="op">+</span> <span class="fu">max</span> <span class="dv">2</span> <span class="dv">0</span></span>
 <span id="cb357-13"><a href="#cb357-13" aria-hidden="true" tabindex="-1"></a>  <span class="op">==&gt;</span> <span class="dv">3</span></span></code></pre></div>
 <p>In case you’re familiar with <em>binary search trees</em>, here are
-the definitions of the lookup and insert opertions for a binary search
+the definitions of the lookup and insert operations for a binary search
 tree. If you don’t know what I’m talking about, you don’t need to
 understand this.</p>
 <div class="sourceCode" id="cb358"><pre
@@ -5695,7 +5695,7 @@ skills from the previous lectures.</p>
 <h2 data-number="7.1" id="modeling-with-boxes"><span
 class="header-section-number">7.1</span> Modeling with Boxes</h2>
 <p>Sometimes you don’t need a new type, but instead can just reuse a
-standard type. For example, repesenting car register plate numbers with
+standard type. For example, representing car register plate numbers with
 <code>String</code>. However, if your code is full of
 <code>String</code>s, it can be easy to accidentally mix up e.g. a car’s
 model and registration in a function like
@@ -6284,7 +6284,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb454-1"><
 <span id="cb454-7"><a href="#cb454-7" aria-hidden="true" tabindex="-1"></a><span class="dt">Hello</span>, <span class="dt">Seraphim</span></span></code></pre></div>
 <h3 data-number="8.1.1" id="what-about-purity"><span
 class="header-section-number">8.1.1</span> What About Purity?</h3>
-<p>It feels as if we can just do side effects where ever we want with
+<p>It feels as if we can just do side effects wherever we want with
 these IO actions. However, it’s important to remember the distinction
 between <em>defining</em> an IO action and <em>executing</em> it.</p>
 <p>Let’s try to print while mapping over a list</p>

--- a/part2.html
+++ b/part2.html
@@ -1324,7 +1324,7 @@ multipliers:  3  7  1  3  7
               3+ 7+ 6+ 3+14 = 33
 check digit is 7, 33+7=40 is divisible by 10, valid</code></pre>
 <p>Here’s the Haskell code for a transaction number checker. Note how we
-use use the infinite list <code>cycle [7,3,1]</code> for the
+use the infinite list <code>cycle [7,3,1]</code> for the
 multipliers.</p>
 <div class="sourceCode" id="cb49"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="ot">viitenumeroCheck ::</span> [<span class="dt">Int</span>] <span class="ot">-&gt;</span> <span class="dt">Bool</span></span>
@@ -2105,7 +2105,7 @@ tunnel--&gt;|Room &quot;This is...&quot; [&quot;Go back&quot; o, &quot;Go left&q
 pit-----&gt;|Room &quot;You fall...&quot; []|    treasure---&gt;|Room &quot;A green...&quot; [&quot;Go back&quot; o]|
          +---------------------+                +-------------------------------+</code></pre>
 <p>We’ve now seen three types of recursion. Recursive functions call
-themselves. Recursive types allow us to express arbitarily large
+themselves. Recursive types allow us to express arbitrarily large
 structures. Recursive values are one way to implement infinite
 structures.</p>
 <h2 data-number="10.9" id="something-fun-debug.trace"><span
@@ -2986,7 +2986,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb171-1"><
 <span id="cb171-3"><a href="#cb171-3" aria-hidden="true" tabindex="-1"></a>            operation2 arg            <span class="co">-- run operation with argument</span></span>
 <span id="cb171-4"><a href="#cb171-4" aria-hidden="true" tabindex="-1"></a>            result <span class="ot">&lt;-</span> operation3 arg  <span class="co">-- run operation with argument, store result</span></span>
 <span id="cb171-5"><a href="#cb171-5" aria-hidden="true" tabindex="-1"></a>            <span class="kw">let</span> something <span class="ot">=</span> f result  <span class="co">-- run a pure function f, store result</span></span>
-<span id="cb171-6"><a href="#cb171-6" aria-hidden="true" tabindex="-1"></a>            finalOperation            <span class="co">-- last operation produces the the return value</span></span></code></pre></div>
+<span id="cb171-6"><a href="#cb171-6" aria-hidden="true" tabindex="-1"></a>            finalOperation            <span class="co">-- last operation produces the return value</span></span></code></pre></div>
 <p>The <code>return x</code> operation is an operation that always
 produces value <code>x</code>. When <code>x :: a</code>,
 <code>return x :: IO a</code>.</p>
@@ -3196,7 +3196,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb179-1"><
 <img src="img/mapTreeBefore.svg" alt="A binary tree" />
 <figcaption aria-hidden="true">A binary tree</figcaption>
 </figure>
-<p>After <code>mapTree g</code> the tree would looke like this:</p>
+<p>After <code>mapTree g</code> the tree would look like this:</p>
 <figure>
 <img src="img/mapTreeAfter.svg"
 alt="A binary tree after mapping g into its nodes" />
@@ -3468,7 +3468,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb198-1"><
 <p>However, for performance reasons, the class contains many methods
 (you can see them yourself by checking <code>:info Foldable</code> in
 GHCi!), but when we’re defining an instance for <code>Foldable</code>
-it’s enought to define just <code>foldr</code>.</p>
+it’s enough to define just <code>foldr</code>.</p>
 <p>Another way of thinking of the <code>Foldable</code> class is
 processing elements <em>left-to-right</em>, in other words, if
 <code>Functor</code> was the class for containers, <code>Foldable</code>
@@ -3656,7 +3656,7 @@ trying to understand monads too early when learning Haskell. Monads are
 introduced this late in the course in an attempt to make understanding
 them easier.</p>
 <p>If you find this lecture hard, don’t despair, many others have found
-the topic hard as well. There are many many productive Haskell
+the topic hard as well. There are many productive Haskell
 programmers who have managed to understand monads, so the task is not
 hopeless.</p>
 <p>One final word of caution: monads, like functors, are a concept
@@ -4253,7 +4253,7 @@ instances:</p>
 <div class="sourceCode" id="cb255"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">import</span> <span class="dt">Control.Monad</span></span>
 <span id="cb255-2"><a href="#cb255-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb255-3"><a href="#cb255-3" aria-hidden="true" tabindex="-1"></a><span class="kw">data</span> <span class="dt">Logger</span> a <span class="ot">=</span> <span class="dt">Logger</span> [<span class="dt">String</span>] a  <span class="kw">deriving</span> <span class="dt">Show</span></span>
+<span id="cb255-3"><a href="#cb255-3" aria-hidden="true" tabindex="-1"></a><span class="kw">data</span> <span class="dt">Logger</span> a <span class="ot">=</span> <span class="dt">Logger</span> [<span class="dt">String</span>] a <span class="kw">deriving</span> <span class="dt">Show</span></span>
 <span id="cb255-4"><a href="#cb255-4" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb255-5"><a href="#cb255-5" aria-hidden="true" tabindex="-1"></a><span class="ot">msg ::</span> <span class="dt">String</span> <span class="ot">-&gt;</span> <span class="dt">Logger</span> ()</span>
 <span id="cb255-6"><a href="#cb255-6" aria-hidden="true" tabindex="-1"></a>msg s <span class="ot">=</span> <span class="dt">Logger</span> [s] ()</span>
@@ -4412,7 +4412,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb268-1"><
 <span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">==&gt;</span> ((),[<span class="dv">6</span>,<span class="dv">0</span>,<span class="dv">5</span>,<span class="dv">4</span>,<span class="dv">1</span>])</span></code></pre></div>
 <p><strong>Note!</strong> By the way, the actual implementation of the
 <code>State</code> monad doesn’t have a <code>State</code> constructor
-like our simplified exmaple. If you want to wrap a function into a
+like our simplified example. If you want to wrap a function into a
 <code>State</code> operation, use this helper instead:</p>
 <pre><code>state :: (s -&gt; (a, s)) -&gt; State s a</code></pre>
 <h2 data-number="13.9" id="the-return-of-mapm"><span
@@ -4557,7 +4557,7 @@ and <code>-x</code>:</p>
 <div class="sourceCode" id="cb291"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb291-1"><a href="#cb291-1" aria-hidden="true" tabindex="-1"></a>[<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>] <span class="op">&gt;&gt;=</span> \x <span class="ot">-&gt;</span> [<span class="op">-</span>x,x]</span>
 <span id="cb291-2"><a href="#cb291-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">==&gt;</span> [<span class="op">-</span><span class="dv">1</span>,<span class="dv">1</span>,<span class="op">-</span><span class="dv">2</span>,<span class="dv">2</span>,<span class="op">-</span><span class="dv">3</span>,<span class="dv">3</span>]</span></code></pre></div>
-<p>We can filter out unsuitable values by produing an empty list:</p>
+<p>We can filter out unsuitable values by producing an empty list:</p>
 <div class="sourceCode" id="cb292"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb292-1"><a href="#cb292-1" aria-hidden="true" tabindex="-1"></a>[<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>] <span class="op">&gt;&gt;=</span> \x <span class="ot">-&gt;</span> <span class="kw">if</span> x<span class="op">&gt;</span><span class="dv">1</span> <span class="kw">then</span> [x] <span class="kw">else</span> []</span>
 <span id="cb292-2"><a href="#cb292-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">==&gt;</span> [<span class="dv">2</span>,<span class="dv">3</span>]</span></code></pre></div>
@@ -4673,12 +4673,12 @@ Languages</h2>
 <p>Once you’ve gotten familiar with the concept of a monad, you’ll start
 seeing monadlike things in other languages too. The most well-known
 examples of this are <em>Option types</em>, <em>Java Streams</em> and
-<em>JavaScript promises</em> . If you know these languages or concepts
+<em>JavaScript promises</em>. If you know these languages or concepts
 from before, you might find this section illuminating. If you don’t,
 feel free to skip this.</p>
 <h3 data-number="13.13.1" id="optionals"><span
 class="header-section-number">13.13.1</span> Optionals</h3>
-<p>Many langages have an <a
+<p>Many languages have an <a
 href="https://en.wikipedia.org/wiki/Option_type">option type</a>. This
 type is called <code>Optional&lt;T&gt;</code> in Java,
 <code>std::optional&lt;T&gt;</code> in C++,
@@ -5233,7 +5233,7 @@ href="https://tools.ietf.org/html/rfc2324">your coffee pot</a>, <a
 href="https://support.ring.com/hc/en-us/articles/205385394-The-Protocols-and-Ports-Used-by-Ring-Devices">and
 even your doorbell</a>, all talk to servers using the HTTP protocol.</p>
 <p>Let’s look at how we can set up a simple HTTP server in Haskell. The
-standard low level components for this are called <a
+standard low-level components for this are called <a
 href="https://hackage.haskell.org/package/wai-3.2.3/docs/Network-Wai.html">WAI</a>
 and <a href="https://hackage.haskell.org/package/warp-3.3.23">Warp</a>.
 WAI, the Web Application Interface gives us a way to define how HTTP
@@ -5710,7 +5710,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb350-1"><
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb351-1"><a href="#cb351-1" aria-hidden="true" tabindex="-1"></a><span class="fu">not</span> <span class="op">&lt;$&gt;</span> <span class="dt">Just</span> <span class="dt">True</span>   <span class="op">==&gt;</span> <span class="dt">Just</span> <span class="dt">False</span></span>
 <span id="cb351-2"><a href="#cb351-2" aria-hidden="true" tabindex="-1"></a><span class="fu">not</span> <span class="op">&lt;$&gt;</span> <span class="dt">Nothing</span>     <span class="op">==&gt;</span> <span class="dt">Nothing</span></span>
 <span id="cb351-3"><a href="#cb351-3" aria-hidden="true" tabindex="-1"></a><span class="fu">negate</span> <span class="op">&lt;$&gt;</span> [<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>]  <span class="op">==&gt;</span> [<span class="op">-</span><span class="dv">1</span>,<span class="op">-</span><span class="dv">2</span>,<span class="op">-</span><span class="dv">3</span>]</span></code></pre></div>
-<p>That’s kinda nice on its own, but it really gets to shine when
+<p>That’s kind of nice on its own, but it really gets to shine when
 combined with this Applicative operator:</p>
 <div class="sourceCode" id="cb352"><pre
 class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb352-1"><a href="#cb352-1" aria-hidden="true" tabindex="-1"></a><span class="ot">(&lt;*&gt;) ::</span> <span class="dt">Applicative</span> f <span class="ot">=&gt;</span> f (a <span class="ot">-&gt;</span> b) <span class="ot">-&gt;</span> f a <span class="ot">-&gt;</span> f b</span></code></pre></div>
@@ -5794,7 +5794,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb362-1"><
 <span id="cb362-3"><a href="#cb362-3" aria-hidden="true" tabindex="-1"></a>decreaseSmall <span class="dv">11</span>  <span class="op">==&gt;</span> <span class="dt">Nothing</span></span></code></pre></div>
 <p>Now that we’ve seen all these operators, we can understand the full
 definition of <code>Applicative</code>. All the operators have
-definitions in terms of <code>liftA2</code>, so it’s enought to define
+definitions in terms of <code>liftA2</code>, so it’s enough to define
 <code>liftA2</code> and <code>pure</code> when implementing an
 <code>Applicative</code> instance.</p>
 <div class="sourceCode" id="cb363"><pre


### PR DESCRIPTION
Corrections to spelling and word usage:

* Fixed typos such as "exaclty" to "exactly", "defintions" to "definitions", "quizes" to "quizzes", "succesfully" to "successfully", "reimplementations" to "reimplementation's", "opertions" to "operations", "repesenting" to "representing", "where ever" to "wherever", "arbitarily" to "arbitrarily", "looke" to "look", "enought" to "enough", "exmaple" to "example", "produing" to "producing", "langages" to "languages", "low level" to "low-level", and "kinda" to "kind of".

Minor grammatical improvements:

* Changed "There’s some shorter substrings left" to "There’re some shorter substrings left".
* Removed duplicate word in "produces the the return value".
* Reduced redundancy in "many many productive Haskell programmers" to "many productive Haskell programmers".