### PR TITLE
Fix incorrect reference from 'head' to 'sum' in Quiz 10

### DIFF
--- a/part2.html
+++ b/part2.html
@@ -2321,7 +2321,7 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb117-1"><
 No, because it uses <code>map</code>, which evaluates the whole list.
 </li>
 <li class="correct">
-No, because computing the <code>head</code> of the result needs the
+No, because computing the <code>sum</code> of the result needs the
 whole input list.
 </li>
 <li>


### PR DESCRIPTION
The reference to the used function in the last question of Quiz 10 seems to be incorrect.
Looking at the example above (line 2318) it uses the `sum` function in the `map` call instead of the `head` function.